### PR TITLE
Use immutable ref in pre-commit docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ To do so, add the following to the `.pre-commit-config.yaml` file at the root of
 ```yaml
 repos:
   - repo: https://github.com/wemake-services/dotenv-linter
-    rev: master
+    rev: 0.2.0  # Use the ref you want to point at
     hooks:
       - id: dotenv-linter
 ```


### PR DESCRIPTION
Use immutable ref instead of a branch name in `pre-commit` usage instructions.

Here's the `pre-commit` docs and rationale on this: https://pre-commit.com/#using-the-latest-version-for-a-repository

This PR uses one of the two documentation style suggestions by the `pre-commit` author https://github.com/psf/black/issues/420#issue-343804354

Note that a version that includes the `.pre-commit-hooks.yml` file needs to be tagged before this works. I made the documented example version `0.2.0` but perhaps it should be `0.1.6`? Which one is expected to be released next?