### PR TITLE
Fix warning output parser in ci

### DIFF
--- a/dotenv_linter/grammar/lexer.py
+++ b/dotenv_linter/grammar/lexer.py
@@ -27,7 +27,6 @@ class DotenvLexer:  # noqa: WPS214
     """Custom lexer wrapper, grouping methods and attrs together."""
 
     tokens: ClassVar[tuple[str, ...]] = (
-        'WHITESPACE',
         'COMMENT',
         'NAME',
         'EQUAL',

--- a/dotenv_linter/grammar/parser.py
+++ b/dotenv_linter/grammar/parser.py
@@ -56,7 +56,11 @@ class DotenvParser:  # noqa: WPS214
     def __init__(self, **kwarg: Any) -> None:
         """Creates inner parser instance."""
         self._lexer = DotenvLexer()
-        self._parser = yacc.yacc(module=self, **kwarg)  # should be last
+        self._parser = yacc.yacc(
+            module=self,
+            debug=False,
+            **kwarg,
+        )  # should be last
 
     def parse(self, to_parse: str, **kwargs: Any) -> Module:
         """Parses input string to FST."""

--- a/dotenv_linter/grammar/parsetab.py
+++ b/dotenv_linter/grammar/parsetab.py
@@ -6,7 +6,7 @@ _tabversion = '3.10'
 
 _lr_method = 'LALR'
 
-_lr_signature = 'COMMENT EQUAL NAME VALUE WHITESPACE\n        body :\n             | body line\n        \n        line : assign\n             | name\n             | comment\n        \n        assign : NAME EQUAL\n               | NAME EQUAL VALUE\n        name : NAMEcomment : COMMENT'
+_lr_signature = 'COMMENT EQUAL NAME VALUE\n        body :\n             | body line\n        \n        line : assign\n             | name\n             | comment\n        \n        assign : NAME EQUAL\n               | NAME EQUAL VALUE\n        name : NAMEcomment : COMMENT'
     
 _lr_action_items = {'NAME':([0,1,2,3,4,5,6,7,8,9,],[-1,6,-2,-3,-4,-5,-8,-9,-6,-7,]),'COMMENT':([0,1,2,3,4,5,6,7,8,9,],[-1,7,-2,-3,-4,-5,-8,-9,-6,-7,]),'$end':([0,1,2,3,4,5,6,7,8,9,],[-1,0,-2,-3,-4,-5,-8,-9,-6,-7,]),'EQUAL':([6,],[8,]),'VALUE':([8,],[9,]),}
 
@@ -27,13 +27,13 @@ for _k, _v in _lr_goto_items.items():
 del _lr_goto_items
 _lr_productions = [
   ("S' -> body","S'",1,None,None,None),
-  ('body -> <empty>','body',0,'p_body','parser.py',69),
-  ('body -> body line','body',2,'p_body','parser.py',70),
-  ('line -> assign','line',1,'p_line','parser.py',78),
-  ('line -> name','line',1,'p_line','parser.py',79),
-  ('line -> comment','line',1,'p_line','parser.py',80),
-  ('assign -> NAME EQUAL','assign',2,'p_assign','parser.py',86),
-  ('assign -> NAME EQUAL VALUE','assign',3,'p_assign','parser.py',87),
-  ('name -> NAME','name',1,'p_name','parser.py',97),
-  ('comment -> COMMENT','comment',1,'p_comment','parser.py',101),
+  ('body -> <empty>','body',0,'p_body','parser.py',73),
+  ('body -> body line','body',2,'p_body','parser.py',74),
+  ('line -> assign','line',1,'p_line','parser.py',82),
+  ('line -> name','line',1,'p_line','parser.py',83),
+  ('line -> comment','line',1,'p_line','parser.py',84),
+  ('assign -> NAME EQUAL','assign',2,'p_assign','parser.py',90),
+  ('assign -> NAME EQUAL VALUE','assign',3,'p_assign','parser.py',91),
+  ('name -> NAME','name',1,'p_name','parser.py',101),
+  ('comment -> COMMENT','comment',1,'p_comment','parser.py',105),
 ]


### PR DESCRIPTION
# I have made things!

## Checklist

- [X] I have double checked that there are no unrelated changes in this pull request (old patches, accidental config files, etc)
- [ ] I have created at least one test case for the changes I have made
- [ ] I have updated the documentation for the changes I have made
- [ ] I have added my changes to the `CHANGELOG.md`

## Related issues
- Closes #755

## 
I have tested various solutions by changing the launch action in my repository.
Unfortunately just disabling the debug mod did nothing, and the warning about unused token still fails the launch -https://github.com/ApostolFet/dotenv-linter/actions/runs/14285573934/job/40040245973

I tried to use the token here and it was successful, but it seems to be a less than optimal solution - https://github.com/ApostolFet/dotenv-linter/actions/runs/14285628449/job/40040356849

In the end, I deleted the unused token (it seems it really wasn't used). CI goes through - https://github.com/ApostolFet/dotenv-linter/actions/runs/14295211209/job/40061485838
Locally, the tests also passed.