### PR TITLE
Fix circular dependency in documentation Makefile

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -15,5 +15,5 @@ help:
 
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
-%: Makefile
+%:
 	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)


### PR DESCRIPTION
# I have made things!

## Summary

The Sphinx catch-all rule used `Makefile` as its own prerequisite. GNU Make applies that pattern while checking the loaded Makefile, so every documentation command reports that the circular dependency was dropped.

This removes only the self-prerequisite. The Sphinx recipe and target routing remain unchanged.

## Validation

- Reproduced the warning before the change with `make -C docs SPHINXBUILD=true`
- Verified the default, `help`, `html`, and `linkcheck` targets no longer report a cycle
- Built all documentation with Sphinx 8.2.3 using warnings-as-errors
- Ruff, formatting, Flake8, mypy, codespell, and dependency checks pass
- 78 tests pass with 100% coverage
- `git diff --check` passes

## Checklist

- [x] I have double checked that there are no unrelated changes in this pull request (old patches, accidental config files, etc)
- [ ] I have created at least one test case for the changes I have made
- [ ] I have updated the documentation for the changes I have made
- [ ] I have added my changes to the `CHANGELOG.md`

## Related issues

Closes #995
