### PR TITLE
small improvements

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,15 +46,7 @@ jobs:
         poetry install
 
     - name: Run checks
-      run: |
-        poetry run ruff check --exit-non-zero-on-fix --diff
-        poetry run ruff format --check --diff
-        poetry run flake8 .
-        poetry run mypy dotenv_linter
-        poetry run codespell dotenv_linter tests docs README.md CHANGELOG.md CONTRIBUTING.md
-        poetry run pytest
-        poetry check
-        poetry run pip check
+      run: make test
 
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v7.0.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -58,6 +58,18 @@ repos:
     hooks:
       - id: check-useless-excludes
 
+  - repo: https://github.com/crate-ci/typos
+    rev: v1
+    hooks:
+      - id: typos
+
+  - repo: https://github.com/codespell-project/codespell
+    rev: v2.4.3
+    hooks:
+    - id: codespell
+      additional_dependencies:
+        - tomli
+
 ci:
   autofix_commit_msg: "[pre-commit.ci] auto fixes from pre-commit.com hooks"
   autofix_prs: true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -72,6 +72,22 @@ If you have added new functionality or features, make sure you have added a test
 for that functionality or feature
 
 
+## Spellcheckers
+
+This project is developed by a diverse and multilingual group of people.
+Many of us are not English native speakers and we also know that people can make mistakes and typos even in the simplest of words.
+
+So, that's why we use a bunch of tools to find and fix spelling and grammar. We use `codespell` to find and fix spelling and grammar.
+You can use it:
+
+```bash
+codespell dotenv_linter tests docs README.md CHANGELOG.md CONTRIBUTING.md
+```
+
+## One magic command
+
+Run `make test` to run everything we have!
+
 ## Step 7
 
 ### Pull Request

--- a/dotenv_linter/violations/base.py
+++ b/dotenv_linter/violations/base.py
@@ -20,14 +20,14 @@ class BaseViolation:
     def as_line(self) -> str:
         """Converts violation to a single line information."""
         violation = self.error_template.format(self._text)
-        return f'{self.location()} {self._formated_code()} {violation}'
+        return f'{self.location()} {self._formatted_code()} {violation}'
 
     def location(self) -> int:
         """Returns in-file location of a violation."""
         raise NotImplementedError('Should be redefined in a subclass')
 
     @final
-    def _formated_code(self) -> str:
+    def _formatted_code(self) -> str:
         return str(self.code).zfill(3)
 
 


### PR DESCRIPTION
# I have made things!

`contributing.md` file currently does not contain a section about ``codespell``, but is used in CI, and it is not included in the `make test` target.
I have improved the CI workflow so that it now simply runs `make test` instead of invoking all commands separately, also improve `contributing.md`, made it look like in WPS contributing.

Also, what about adding codespell to the WPS CI?

<!--
Hi, thanks for submitting a Pull Request. We appreciate it.

Please, fill in all the required information
to make our review and merging processes easier.

Cheers!
-->

## Checklist

<!-- Please check everything that applies: -->

- [x] I have double checked that there are no unrelated changes in this pull request (old patches, accidental config files, etc)
- [ ] I have created at least one test case for the changes I have made
- [ ] I have updated the documentation for the changes I have made
- [ ] I have added my changes to the `CHANGELOG.md`

## Related issues

<!--
Mark what issues this Pull Request closes or references.

Format is:
- Closes #issue-number
- Refs #issue-number

Example. Refs #0
Documentation: https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/
-->

<!--
If you have any feedback, just write it here.

It can be whatever you want!
-->
